### PR TITLE
Unmarshal numbers as numbers instead of floats

### DIFF
--- a/jsonindent.go
+++ b/jsonindent.go
@@ -56,6 +56,7 @@ func main() {
 
 func jsonindent(r io.Reader) {
 	d := json.NewDecoder(r)
+	d.UseNumber()
 	var e error
 	for e == nil {
 		var v interface{}


### PR DESCRIPTION
What the the subject says. Without this change, the unmarshaling loses the precision of large integer values. This is especially awkward when these integer values are numeric IDs.
